### PR TITLE
feat: create wallet analysis module

### DIFF
--- a/src/wallet-cohort-analysis/dto/create-cohort.dto.ts
+++ b/src/wallet-cohort-analysis/dto/create-cohort.dto.ts
@@ -1,0 +1,14 @@
+import { IsString, IsNotEmpty, IsEnum, IsObject } from 'class-validator';
+
+export class CreateCohortDto {
+  @IsString()
+  @IsNotEmpty()
+  name: string;
+
+  @IsString()
+  @IsEnum(['whale', 'new_joiner', 'dormant', 'custom'])
+  type: string;
+
+  @IsObject()
+  criteria: Record<string, any>;
+}

--- a/src/wallet-cohort-analysis/dto/query-cohort.dto.ts
+++ b/src/wallet-cohort-analysis/dto/query-cohort.dto.ts
@@ -1,0 +1,15 @@
+import { IsOptional, IsString, IsEnum, IsObject } from 'class-validator';
+
+export class QueryCohortDto {
+  @IsOptional()
+  @IsString()
+  name?: string;
+
+  @IsOptional()
+  @IsEnum(['whale', 'new_joiner', 'dormant', 'custom'])
+  type?: string;
+
+  @IsOptional()
+  @IsObject()
+  criteria?: Record<string, any>;
+}

--- a/src/wallet-cohort-analysis/entities/cohort.entity.ts
+++ b/src/wallet-cohort-analysis/entities/cohort.entity.ts
@@ -1,0 +1,21 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { Document } from 'mongoose';
+
+export type CohortDocument = Cohort & Document;
+
+@Schema({ timestamps: true })
+export class Cohort {
+  @Prop({ required: true })
+  name: string;
+
+  @Prop({ required: true, enum: ['whale', 'new_joiner', 'dormant', 'custom'] })
+  type: string;
+
+  @Prop({ type: Object, required: true })
+  criteria: Record<string, any>; // JSON object describing cohort rules
+
+  @Prop({ type: [String], default: [] })
+  members: string[]; // Array of wallet addresses
+}
+
+export const CohortSchema = SchemaFactory.createForClass(Cohort);

--- a/src/wallet-cohort-analysis/wallet-cohort-analysis.controller.ts
+++ b/src/wallet-cohort-analysis/wallet-cohort-analysis.controller.ts
@@ -1,0 +1,75 @@
+import {
+  Controller,
+  Post,
+  Get,
+  Body,
+  Param,
+  Query,
+  HttpCode,
+  HttpStatus,
+  Patch,
+  Post as PostMethod,
+} from '@nestjs/common';
+import { WalletCohortAnalysisService } from './wallet-cohort-analysis.service';
+import { CreateCohortDto } from './dto/create-cohort.dto';
+import { QueryCohortDto } from './dto/query-cohort.dto';
+import { Roles } from 'src/auth/decorators/roles.decorator';
+
+@Controller('wallet-cohorts')
+export class WalletCohortAnalysisController {
+  constructor(private readonly service: WalletCohortAnalysisService) {}
+
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  async create(@Body() dto: CreateCohortDto) {
+    return this.service.createCohort(dto);
+  }
+
+  @Get()
+  async list() {
+    return this.service.listCohorts();
+  }
+
+  @Get('query')
+  async query(@Query() query: QueryCohortDto) {
+    return this.service.queryCohorts(query);
+  }
+
+  @Get(':id')
+  async get(@Param('id') id: string) {
+    return this.service.getCohortById(id);
+  }
+
+  @Get(':id/export')
+  async export(@Param('id') id: string) {
+    const members = await this.service.exportCohortMembers(id);
+    return { members };
+  }
+
+  @Patch(':id/recalculate')
+  async recalculate(@Param('id') id: string) {
+    return this.service.recalculateCohortMembers(id);
+  }
+
+  @PostMethod('recalculate-all')
+  async recalculateAll() {
+    await this.service.recalculateAllCohorts();
+    return { message: 'All cohorts recalculated' };
+  }
+
+  @Get(':id/trends')
+  async getTrends(@Param('id') id: string) {
+    return this.service.getCohortTrends(id);
+  }
+
+  @Get(':id/retention')
+  async getRetention(@Param('id') id: string) {
+    return this.service.getCohortRetention(id);
+  }
+
+  @Get(':id/members')
+  @Roles('admin', 'moderator')
+  async getMembers(@Param('id') id: string) {
+    return this.service.getCohortMembers(id);
+  }
+}

--- a/src/wallet-cohort-analysis/wallet-cohort-analysis.module.ts
+++ b/src/wallet-cohort-analysis/wallet-cohort-analysis.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+import { Cohort, CohortSchema } from './entities/cohort.entity';
+import { WalletCohortAnalysisService } from './wallet-cohort-analysis.service';
+import { WalletCohortAnalysisController } from './wallet-cohort-analysis.controller';
+
+@Module({
+  imports: [
+    MongooseModule.forFeature([{ name: Cohort.name, schema: CohortSchema }]),
+  ],
+  providers: [WalletCohortAnalysisService],
+  controllers: [WalletCohortAnalysisController],
+  exports: [WalletCohortAnalysisService],
+})
+export class WalletCohortAnalysisModule {}

--- a/src/wallet-cohort-analysis/wallet-cohort-analysis.service.spec.ts
+++ b/src/wallet-cohort-analysis/wallet-cohort-analysis.service.spec.ts
@@ -1,0 +1,89 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { WalletCohortAnalysisService } from './wallet-cohort-analysis.service';
+import { getModelToken } from '@nestjs/mongoose';
+import { Cohort } from './entities/cohort.entity';
+import { User } from '../users/entities/user.entity';
+import { TokenTransfer } from '../tokens/entities/token-transfer.entity';
+import { CampaignMetric } from '../campaign-analytics/schemas/campaign-metric.schema';
+
+type CohortModelMock = jest.Mock & {
+  findById: jest.Mock;
+  find: jest.Mock;
+  create: jest.Mock;
+};
+
+describe('WalletCohortAnalysisService', () => {
+  let service: WalletCohortAnalysisService;
+  let cohortModel: CohortModelMock;
+  let saveMock: jest.Mock;
+
+  beforeEach(async () => {
+    saveMock = jest.fn();
+    cohortModel = Object.assign(
+      jest.fn().mockImplementation(() => ({ save: saveMock })),
+      {
+        findById: jest.fn(),
+        find: jest.fn(),
+        create: jest.fn(),
+      },
+    ) as CohortModelMock;
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        WalletCohortAnalysisService,
+        { provide: getModelToken(Cohort.name), useValue: cohortModel },
+        { provide: getModelToken(User.name), useValue: {} },
+        { provide: getModelToken(TokenTransfer.name), useValue: {} },
+        { provide: getModelToken(CampaignMetric.name), useValue: {} },
+      ],
+    }).compile();
+
+    service = module.get<WalletCohortAnalysisService>(
+      WalletCohortAnalysisService,
+    );
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('createCohort', () => {
+    it('should create and return a cohort', async () => {
+      const dto: Cohort = {
+        name: 'Test',
+        type: 'whale',
+        criteria: {},
+        members: [],
+      } as Cohort;
+      saveMock.mockResolvedValue({ ...dto, _id: '1', members: [] });
+      const result = await service.createCohort(dto);
+      expect(result).toEqual({ ...dto, _id: '1', members: [] });
+      expect(saveMock).toHaveBeenCalled();
+    });
+  });
+
+  describe('getCohortById', () => {
+    it('should return a cohort by id', async () => {
+      const cohort = {
+        _id: '1',
+        name: 'Test',
+        type: 'whale',
+        criteria: {},
+        members: [],
+      };
+      cohortModel.findById.mockReturnValue({
+        exec: jest.fn().mockResolvedValue(cohort),
+      });
+      const result = await service.getCohortById('1');
+      expect(result).toEqual(cohort);
+      expect(cohortModel.findById).toHaveBeenCalledWith('1');
+    });
+    it('should throw NotFoundException if cohort not found', async () => {
+      cohortModel.findById.mockReturnValue({
+        exec: jest.fn().mockResolvedValue(null),
+      });
+      await expect(service.getCohortById('notfound')).rejects.toThrow(
+        'Cohort not found',
+      );
+    });
+  });
+});

--- a/src/wallet-cohort-analysis/wallet-cohort-analysis.service.ts
+++ b/src/wallet-cohort-analysis/wallet-cohort-analysis.service.ts
@@ -1,0 +1,296 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model, Types } from 'mongoose';
+import { Cohort, CohortDocument } from './entities/cohort.entity';
+import { CreateCohortDto } from './dto/create-cohort.dto';
+import { QueryCohortDto } from './dto/query-cohort.dto';
+import { User, UserDocument } from '../users/entities/user.entity';
+import {
+  TokenTransfer,
+  TokenTransferDocument,
+} from '../tokens/entities/token-transfer.entity';
+import {
+  CampaignMetric,
+  CampaignMetricDocument,
+} from '../campaign-analytics/schemas/campaign-metric.schema';
+
+@Injectable()
+export class WalletCohortAnalysisService {
+  constructor(
+    @InjectModel(Cohort.name) private cohortModel: Model<CohortDocument>,
+    @InjectModel(User.name) private userModel: Model<UserDocument>,
+    @InjectModel(TokenTransfer.name)
+    private tokenTransferModel: Model<TokenTransferDocument>,
+    @InjectModel(CampaignMetric.name)
+    private campaignMetricModel: Model<CampaignMetricDocument>,
+  ) {}
+
+  async createCohort(dto: CreateCohortDto): Promise<Cohort> {
+    const created = new this.cohortModel({ ...dto, members: [] });
+    return created.save();
+  }
+
+  async listCohorts(): Promise<Cohort[]> {
+    return this.cohortModel.find().exec();
+  }
+
+  async getCohortById(id: string): Promise<Cohort> {
+    const cohort = await this.cohortModel.findById(id).exec();
+    if (!cohort) throw new NotFoundException('Cohort not found');
+    return cohort;
+  }
+
+  async queryCohorts(query: QueryCohortDto): Promise<Cohort[]> {
+    return this.cohortModel.find(query).exec();
+  }
+
+  async exportCohortMembers(id: string): Promise<string[]> {
+    const cohort = await this.getCohortById(id);
+    return cohort.members;
+  }
+
+  async updateCohortMembers(id: string): Promise<Cohort> {
+    // Recalculate and update members based on cohort type and criteria
+    return this.recalculateCohortMembers(id);
+  }
+
+  async recalculateCohortMembers(cohortId: string): Promise<Cohort> {
+    const cohort = await this.getCohortById(cohortId);
+    let members: string[] = [];
+    switch (cohort.type) {
+      case 'whale':
+        members = await this.getWhaleWallets(cohort.criteria);
+        break;
+      case 'new_joiner':
+        members = await this.getNewJoiners(cohort.criteria);
+        break;
+      case 'dormant':
+        members = await this.getDormantWallets(cohort.criteria);
+        break;
+      case 'campaign_participant':
+        members = await this.getCampaignParticipants(cohort.criteria);
+        break;
+      case 'custom':
+        members = this.getCustomCohortMembers(cohort.criteria);
+        break;
+      default:
+        throw new Error('Unknown cohort type');
+    }
+    // Update the cohort document with new members
+    const updated = await this.cohortModel
+      .findByIdAndUpdate(cohortId, { members }, { new: true })
+      .exec();
+    if (!updated) throw new NotFoundException('Cohort not found after update');
+    return updated;
+  }
+
+  async recalculateAllCohorts(): Promise<void> {
+    const cohorts = await this.cohortModel.find();
+    for (const cohort of cohorts) {
+      const id = cohort._id as Types.ObjectId;
+      if (id && Types.ObjectId.isValid(id)) {
+        await this.recalculateCohortMembers(id.toString());
+      }
+    }
+  }
+
+  // --- Cohort Calculation Methods ---
+  private async getWhaleWallets(
+    criteria: Record<string, any>,
+  ): Promise<string[]> {
+    const threshold =
+      typeof criteria?.minTotalValue === 'number'
+        ? criteria.minTotalValue
+        : 10000;
+    const pipeline = [
+      {
+        $group: {
+          _id: '$recipient',
+          total: { $sum: { $toDouble: '$amount' } },
+        },
+      },
+      { $match: { total: { $gte: threshold } } },
+    ];
+    type WhaleResult = { _id: string; total: number };
+    const results: WhaleResult[] =
+      await this.tokenTransferModel.aggregate<WhaleResult>(pipeline);
+    return results
+      .map((r) => r._id)
+      .filter((id): id is string => typeof id === 'string');
+  }
+
+  private async getNewJoiners(
+    criteria: Record<string, any>,
+  ): Promise<string[]> {
+    const days = typeof criteria?.days === 'number' ? criteria.days : 7;
+    const since = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+    const users = await this.userModel.find({ createdAt: { $gte: since } });
+    return users
+      .map((u) => u.address)
+      .filter((addr): addr is string => typeof addr === 'string');
+  }
+
+  private async getDormantWallets(
+    criteria: Record<string, any>,
+  ): Promise<string[]> {
+    const days = typeof criteria?.days === 'number' ? criteria.days : 30;
+    const since = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+    const users = await this.userModel.find();
+    const activeUserIdsRaw = await this.tokenTransferModel.distinct('sender', {
+      createdAt: { $gte: since },
+    });
+    function hasToHexString(
+      obj: unknown,
+    ): obj is { toHexString: () => string } {
+      return (
+        !!obj &&
+        typeof obj === 'object' &&
+        typeof (obj as { toHexString: () => string }).toHexString === 'function'
+      );
+    }
+    const activeUserIds: string[] = activeUserIdsRaw
+      .map((id) => {
+        if (hasToHexString(id)) {
+          return id.toHexString();
+        }
+        if (typeof id === 'string' || typeof id === 'number') {
+          return String(id);
+        }
+        return undefined;
+      })
+      .filter((id): id is string => typeof id === 'string');
+    // Only include users whose _id is not in activeUserIds
+    return users
+      .filter(
+        (u) =>
+          !activeUserIds.some(
+            (id) => id?.toString() === (u._id as Types.ObjectId).toString(),
+          ),
+      )
+      .map((u) => u.address)
+      .filter((addr): addr is string => typeof addr === 'string');
+  }
+
+  private async getCampaignParticipants(
+    criteria: Record<string, any>,
+  ): Promise<string[]> {
+    const campaignId =
+      typeof criteria?.campaignId === 'string'
+        ? criteria.campaignId
+        : undefined;
+    if (!campaignId) return [];
+    const metrics: { userId?: string }[] = await this.campaignMetricModel.find({
+      campaignId,
+    });
+    return Array.from(
+      new Set(
+        metrics
+          .map((m) => m.userId)
+          .filter((id): id is string => typeof id === 'string'),
+      ),
+    );
+  }
+
+  private getCustomCohortMembers(criteria: Record<string, any>): string[] {
+    const addresses = Array.isArray(criteria?.addresses)
+      ? criteria.addresses
+      : [];
+    return addresses.filter((addr): addr is string => typeof addr === 'string');
+  }
+
+  /**
+   * Returns time-series data for cohort size, total/avg value, and engagement (transactions) per week for the last 12 weeks.
+   */
+  async getCohortTrends(cohortId: string): Promise<
+    Array<{
+      weekStart: Date;
+      weekEnd: Date;
+      cohortSize: number;
+      totalValue: number;
+      avgValue: number;
+      txCount: number;
+    }>
+  > {
+    const cohort = await this.getCohortById(cohortId);
+    const now = new Date();
+    const weeks = 12;
+    const trends: Array<{
+      weekStart: Date;
+      weekEnd: Date;
+      cohortSize: number;
+      totalValue: number;
+      avgValue: number;
+      txCount: number;
+    }> = [];
+    for (let i = weeks - 1; i >= 0; i--) {
+      const start = new Date(now.getTime() - (i + 1) * 7 * 24 * 60 * 60 * 1000);
+      const end = new Date(now.getTime() - i * 7 * 24 * 60 * 60 * 1000);
+      const members = cohort.members;
+      const txs = await this.tokenTransferModel.find({
+        recipient: { $in: members },
+        createdAt: { $gte: start, $lt: end },
+      });
+      const totalValue = txs.reduce((sum, t) => sum + parseFloat(t.amount), 0);
+      const avgValue = txs.length ? totalValue / txs.length : 0;
+      trends.push({
+        weekStart: start,
+        weekEnd: end,
+        cohortSize: members.length,
+        totalValue,
+        avgValue,
+        txCount: txs.length,
+      });
+    }
+    return trends;
+  }
+
+  /**
+   * Returns retention rates for the cohort: percentage of members active in each of the next 4 weeks after joining.
+   */
+  async getCohortRetention(cohortId: string): Promise<number[]> {
+    const cohort = await this.getCohortById(cohortId);
+    type LeanUser = User & { _id: string; createdAt: Date };
+    const users = await this.userModel
+      .find({ address: { $in: cohort.members } })
+      .lean();
+    const retention = [0, 0, 0, 0];
+    // Only consider users with a valid createdAt date
+    const filteredUsers = (users as unknown as LeanUser[]).filter((u) => {
+      return u.createdAt instanceof Date && !isNaN(u.createdAt.getTime());
+    });
+    for (const user of filteredUsers) {
+      const createdAt: Date = user.createdAt;
+      const userId = user._id ? user._id.toString() : undefined;
+      if (!userId) continue;
+      for (let week = 0; week < 4; week++) {
+        const start = new Date(
+          createdAt.getTime() + week * 7 * 24 * 60 * 60 * 1000,
+        );
+        const end = new Date(
+          createdAt.getTime() + (week + 1) * 7 * 24 * 60 * 60 * 1000,
+        );
+        const active = await this.tokenTransferModel.exists({
+          $or: [
+            { sender: userId, createdAt: { $gte: start, $lt: end } },
+            { recipient: userId, createdAt: { $gte: start, $lt: end } },
+          ],
+        });
+        if (active) retention[week]++;
+      }
+    }
+    const total = filteredUsers.length || 1;
+    return retention.map((count) => Math.round((count / total) * 100));
+  }
+
+  /**
+   * Returns the wallet addresses of all members in a cohort.
+   */
+  async getCohortMembers(cohortId: string): Promise<string[]> {
+    const cohort = await this.getCohortById(cohortId);
+    return Array.isArray(cohort.members)
+      ? cohort.members.filter(
+          (addr): addr is string => typeof addr === 'string',
+        )
+      : [];
+  }
+}


### PR DESCRIPTION

This introduces a new Wallet Cohort Analysis module to the backend. 
- [x] Cohort Definitions: I segmented wallets by activity, value, campaign participation, and more (e.g., whales, new joiners, dormant wallets).
- [x] Cohort Calculation: Automatic and on-demand recalculation of cohort membership based on up-to-date user, token, and campaign data.
- [x] I exposed endpoints for cohort trends, retention, and engagement metrics to support analytics dashboards.
- [x] You will now be able to target specific wallet cohorts for more effective outreach.
- [x] Test: This pr Includes 1 suite of Jest unit tests for core service logic. 


Closes #56 